### PR TITLE
chore: add skip ci functionality and fix source map paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
   test:
     name: Test on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -69,7 +69,7 @@ jobs:
           
           # Commit and push
           git add package.json
-          git commit -m "chore: bump version to $NEW_VERSION"
+          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
           git push origin main
 
       - name: Create summary

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
     "skipLibCheck": true,             // Skip type checking of declaration files
     "baseUrl": "./src",               // Base URL for resolving non-relative imports
     "sourceMap": true,                // Generate source maps
+    "sourceRoot": ".",                // Set source root to package root for production-friendly paths
     "inlineSources": true,            // Include source code in source maps
     "paths": {
       "*": ["./*"]                    // Map all paths to the base directory


### PR DESCRIPTION
## Summary
- Add `[skip ci]` to version-bump.yml commit messages to prevent unnecessary CI runs
- Skip test workflow when commit message contains 'skip ci'
- Fix source map paths for production builds

## Changes
- **version-bump.yml**: Added `[skip ci]` to commit message to prevent triggering tests on version bumps
- **test.yml**: Added conditional to skip tests when commit message contains 'skip ci'
- **publish.yml**: Fixed source map paths for production builds

## Test plan
- [ ] Verify version bump commits include `[skip ci]`
- [ ] Confirm test workflow skips when commit contains 'skip ci'
- [ ] Validate source map paths in production builds